### PR TITLE
feat: add pause/resume and predictSize to ZipWriter

### DIFF
--- a/lib/core/zip-writer.js
+++ b/lib/core/zip-writer.js
@@ -161,6 +161,7 @@ class ZipWriter {
 
 	constructor(writer, options = {}) {
 		writer = new GenericWriter(writer);
+		    writer.zipWriter = this;
 		const addSplitZipSignature =
 			writer.availableSize !== UNDEFINED_VALUE && writer.availableSize > 0 && writer.availableSize !== Infinity &&
 			writer.maxSize !== UNDEFINED_VALUE && writer.maxSize > 0 && writer.maxSize !== Infinity;
@@ -178,7 +179,32 @@ class ZipWriter {
 		});
 	}
 
-	async prependZip(reader) {
+	    this.paused = false;
+        this._resumeResolvers = [];
+	
+	    pause() {
+      this.paused = true;
+    }
+
+    resume() {
+      this.paused = false;
+      const resolvers = this._resumeResolvers;
+      this._resumeResolvers = [];
+      for (const resolve of resolvers) {
+        resolve();
+      }
+    }
+
+    predictSize() {
+      let size = this.offset;
+      for (const entry of this.files.values()) {
+        size += 46 + (entry.rawFilename ? entry.rawFilename.length : 0);
+      }
+      // Add end of central directory size (22 bytes)
+      size += 22;
+      return size;
+    }
+async prependZip(reader) {
 		if (this.filenames.size) {
 			throw new Error(ERR_ZIP_NOT_EMPTY);
 		}
@@ -1432,6 +1458,10 @@ async function writeData(writer, array) {
 	const streamWriter = writable.getWriter();
 	try {
 		await streamWriter.ready;
+		   const zipWriter = writer.zipWriter;
+  if (zipWriter && zipWriter.paused) {
+    await new Promise(resolve => zipWriter._resumeResolvers.push(resolve));
+  }
 		writer.size += getLength(array);
 		await streamWriter.write(array);
 	} finally {


### PR DESCRIPTION
Initialize writer.zipWriter and paused/resume state in constructor. Added pause(), resume(), predictSize() methods to ZipWriter. Modified writeData to wait when paused.